### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/handlers/lambda.js
+++ b/handlers/lambda.js
@@ -4,7 +4,7 @@ var Webda = require('../core');
 var SecureCookie = require('../utils/cookie');
 var _extend = require("util")._extend;
 const cookieParse = require("cookie").parse;
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 
 /**
  * The Lambda entrypoint for Webda

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "mime": "1.3.4",
     "mime-types": "^2.1.11",
     "mongodb": ">=2.1.7",
-    "node-uuid": "*",
     "nodemailer": "^2.3.2",
     "nodemailer-ses-transport": "^1.3.0",
     "passport": "=0.2.2",
@@ -29,7 +28,8 @@
     "passport-github2": ">=0.1.9",
     "passport-google-oauth": "=0.2.0",
     "passport-twitter": ">=1.0.3",
-    "uri-templates": ">=0.1.7"
+    "uri-templates": ">=0.1.7",
+    "uuid": "^3.0.0"
   },
   "files": [
     "core.js",

--- a/services/executor.js
+++ b/services/executor.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const uuid = require('node-uuid');
+const uuid = require('uuid');
 const crypto = require('crypto');
 const Service = require('./service');
 

--- a/stores/store.js
+++ b/stores/store.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var stores = {};
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 const Executor = require("../services/executor");
 const _extend = require("util")._extend;
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.