### PR TITLE
S3 redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "webda",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "description": "Expose API with Lambda",
   "keywords": [
     "aws",

--- a/src/services/s3binary.ts
+++ b/src/services/s3binary.ts
@@ -97,8 +97,8 @@ class S3Binary extends AWSMixIn(Binary) {
     return s3obj.putObject().promise();
   }
 
-  async getSignedUrl(action, params): Promise < string > {
-    return this._s3.getSignedUrl(action, params).promise();
+  getSignedUrl(action, params): string {
+    return this._s3.getSignedUrl(action, params);
   }
 
   async getRedirectUrlFromObject(obj, property, index, context, expire = 30) {
@@ -125,7 +125,7 @@ class S3Binary extends AWSMixIn(Binary) {
       throw 404;
     }
     await obj.canAct(ctx, 'get_binary');
-    let url = this.getRedirectUrlFromObject(obj, ctx._params.property, ctx._params.index, ctx);
+    let url = await this.getRedirectUrlFromObject(obj, ctx._params.property, ctx._params.index, ctx);
     ctx.writeHead(302, {
       'Location': url
     });

--- a/test/webda.test.js
+++ b/test/webda.test.js
@@ -53,7 +53,7 @@ describe('Webda', function() {
   });
   describe('getVersion()', function() {
     it('current', function() {
-      assert.equal(webda.getVersion(), '0.9.4');
+      assert.equal(webda.getVersion(), '0.9.5');
     });
   });
   describe('utils', function() {


### PR DESCRIPTION
## Fixes
S3 SDK don't return a AWS.Response on getSignedUrl, so it need to be adapt

Changes proposed in this pull request
